### PR TITLE
Stop crouching being activated in vehicle

### DIFF
--- a/Enhanced_Crouch/client.lua
+++ b/Enhanced_Crouch/client.lua
@@ -31,11 +31,11 @@ RemoveCrouchAnim = function()
 end
 
 CanCrouch = function()
-	if IsPedOnFoot(PlayerInfo.playerPed) and not IsPedInAnyVehicle(PlayerInfo.playerPed, false) and not IsPedJumping(PlayerInfo.playerPed) and not IsPedFalling(PlayerInfo.playerPed) and not IsPedDeadOrDying(PlayerInfo.playerPed) then
-		return true
-	else
-		return false
-	end
+    if IsPedOnFoot(PlayerInfo.playerPed) and not IsPedInAnyVehicle(PlayerInfo.playerPed, false) and not IsPedJumping(PlayerInfo.playerPed) and not IsPedFalling(PlayerInfo.playerPed) and not IsPedDeadOrDying(PlayerInfo.playerPed) then
+        return true
+    else
+        return false
+    end
 end
 
 CrouchPlayer = function()
@@ -113,3 +113,19 @@ IsCrouched = function()
 end
 
 exports("IsCrouched", IsCrouched)
+
+RegisterCommand('crouch', function()
+    DisableControlAction(0, 36, true) -- magic
+    if not Cooldown and not IsPedInAnyVehicle(PlayerPedId(), false) then
+        CrouchedForce = not CrouchedForce
+
+        if CrouchedForce then
+            CreateThread(CrouchLoop) -- Magic Part 2 lamo
+        end
+
+        Cooldown = true
+        SetTimeout(CoolDownTime, function()
+            Cooldown = false
+        end)
+    end
+end, false)


### PR DESCRIPTION
Improved the check for if ped is in vehicle.  Stopped crouch from being activated causing the player to be in crouched state when exiting vehicle.  This is just a small tweak to this script to assist with the issue where when toggling the crouch state afterwards would cause player to be standing but also not be able to go into the first person camera.